### PR TITLE
Update caplinked-api.gemspec

### DIFF
--- a/caplinked-api.gemspec
+++ b/caplinked-api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'activesupport', '~> 4.0'
+  spec.add_dependency 'activesupport', '>= 4.0'
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_dependency 'http', '~> 2.0'
   spec.add_dependency 'http-form_data', '~> 1.0'


### PR DESCRIPTION
Make activesupport dependency compatible with Rails 5