### PR TITLE
Handle array responses and use deep_symbolize_keys

### DIFF
--- a/lib/caplinked/error.rb
+++ b/lib/caplinked/error.rb
@@ -4,7 +4,7 @@ module Caplinked
 
     class << self
       def from_response(body, headers)
-        new(body[:error]['code'], body[:error]['message'], headers)
+        new(body[:error][:code], body[:error][:message], headers)
       end
     end
 

--- a/spec/core/util_spec.rb
+++ b/spec/core/util_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Utils", :type => :utils do
 
     get = client.perform_get("/api/v1/activities/workspace/5886", {})
 
-    expect(get[:pagination]).to include({"total_pages"=>2, "page"=>1, "per_page"=>100})
+    expect(get[:pagination]).to include({:total_pages=>2, :page=>1, :per_page=>100})
     expect(get[:events].count).to eq(100)
   end
 


### PR DESCRIPTION
- Fix error in handling array responses from api (list_all_groups_in_workspace, get_folder_permissions, etc.)

- Use _**deep_symbolize_keys**_ instead of _**symbolize_keys**_ so the keys will be consistent throughout
**api_response[:workspace]['id']** becomes **api_response[:workspace][:id]**

- Change error.rb to expect all keys as symbols