### PR TITLE
remove :message from attr_reader in error.rb

### DIFF
--- a/lib/caplinked/error.rb
+++ b/lib/caplinked/error.rb
@@ -1,6 +1,6 @@
 module Caplinked
   class Error < StandardError
-    attr_reader :code, :message, :headers
+    attr_reader :code, :headers
 
     class << self
       def from_response(body, headers)


### PR DESCRIPTION
This was causing message to return nil on instances of Caplinked::Error