### PR TITLE
Update add group member and add team member

### DIFF
--- a/lib/caplinked/rest/groups.rb
+++ b/lib/caplinked/rest/groups.rb
@@ -61,7 +61,7 @@ module Caplinked
       end
 
       def add_group_member(options = {})
-        body = options.stringify_keys.slice('id', 'user_id', 'workspace_id', 'send_email')
+        body = options.stringify_keys.slice('id', 'user_id', 'email', 'workspace_id', 'send_email')
         id = body.delete('id')
         perform_post('/api/v1/groups/' + id.to_s + '/memberships', {}, body.to_json, { 'Content-Type' => 'application/json' } )
       end

--- a/lib/caplinked/rest/teams.rb
+++ b/lib/caplinked/rest/teams.rb
@@ -24,7 +24,7 @@ module Caplinked
       end
 
       def add_team_member(options = {})
-        body = options.stringify_keys.slice('id', 'user_id')
+        body = options.stringify_keys.slice('id', 'user_id', 'email')
         id = body.delete('id')
         perform_post('/api/v1/teams/' + id.to_s + '/memberships', {}, body.to_json, { 'Content-Type' => 'application/json' } )
       end


### PR DESCRIPTION
Accepts email as param to identify a user when adding to a team or group. This appears to be the way the API works from the documentation.